### PR TITLE
prevent jumping on multi line when length is 0

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -403,13 +403,14 @@ export default class TextField extends PureComponent {
   onContentSizeChange(event) {
     let { onContentSizeChange, fontSize } = this.props;
     let { height } = event.nativeEvent.contentSize;
-
+    let { length: count } = this.value();
+    
     if ('function' === typeof onContentSizeChange) {
       onContentSizeChange(event);
     }
 
     this.setState({
-      height: Math.max(
+      height: count == 0 ? fontSize * 1.5 : Math.max(
         fontSize * 1.5,
         Math.ceil(height) + Platform.select({ ios: 4, android: 1 })
       ),


### PR DESCRIPTION
On multi line text field, when user deletes all content, the recalculation of its height caused an annoying "jump".